### PR TITLE
Fix download url (add missing version prefix)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ script:
   - asdf plugin-add aws-iam-authenticator ./
   - asdf list-all aws-iam-authenticator
   - asdf plugin-test aws-iam-authenticator ./ 'aws-iam-authenticator version' --asdf-tool-version 0.4.0-alpha.1
+  - asdf plugin-test aws-iam-authenticator ./ 'aws-iam-authenticator version' --asdf-tool-version v0.4.0
 os:
   - linux
   - osx

--- a/bin/install
+++ b/bin/install
@@ -30,12 +30,13 @@ install_aws-iam-authenticator() {
   rm -f $binary_path 2>/dev/null || true
 
   echo "Copying binary"
-  cp "${tmp_download_dir}/aws-iam-authenticator_${version}_${platform}" ${binary_path}
+  cp ${download_path} ${binary_path}
   chmod +x ${binary_path}
 }
 
 get_filename() {
-  local version="$1"
+  # Strip v prefix from version
+  local version=$(echo $1 | sed 's/v\{0,1\}//;s///')
   local platform="$2"
 
   echo "aws-iam-authenticator_${version}_${platform}"
@@ -46,7 +47,7 @@ get_download_url() {
   local platform="$2"
   local filename="$(get_filename $version $platform)"
 
-  echo "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${version}/${filename}"
+  echo "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/${version}/${filename}"
 }
 
 install_aws-iam-authenticator $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH

--- a/bin/install
+++ b/bin/install
@@ -46,7 +46,7 @@ get_download_url() {
   local platform="$2"
   local filename="$(get_filename $version $platform)"
 
-  echo "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/${version}/${filename}"
+  echo "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${version}/${filename}"
 }
 
 install_aws-iam-authenticator $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH

--- a/bin/list-all
+++ b/bin/list-all
@@ -14,5 +14,5 @@ function sort_versions() {
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"v\{0,1\}//;s/\",//')
+versions=$(eval $cmd | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"\{0,1\}//;s/\",//')
 echo $versions


### PR DESCRIPTION
Hi,

The current download URLs don't seem to work anymore; I think it's missing a `v` prefix... 

i.e. 

    https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.4.0/aws-iam-authenticator_0.4.0_linux_amd64

instead of 

    https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/0.4.0/aws-iam-authenticator_0.4.0_linux_amd64

